### PR TITLE
Fix/uppsf 1824 list republish order

### DIFF
--- a/pkg/republisher/uuid_republisher.go
+++ b/pkg/republisher/uuid_republisher.go
@@ -85,7 +85,7 @@ func (r *NotifyingUUIDRepublisher) Republish(uuid, tidPrefix string, republishSc
 			return nil, errs
 		}
 		log.Infof("uuid=%v was found to be an ImageSet having an imageModelUUID=%v", uuid, imageModelUUID)
-		msg, isFound, err := r.ucRepublisher.RepublishUUIDFromCollection(imageModelUUID, tid, r.collections["universal-content"])
+		msg, isFound, err := r.ucRepublisher.RepublishUUIDFromCollection(imageModelUUID, tid, r.collections["methode"])
 		if err != nil {
 			errs = append(errs, fmt.Errorf("error publishing %v", err))
 			return nil, errs

--- a/pkg/republisher/uuid_republisher.go
+++ b/pkg/republisher/uuid_republisher.go
@@ -31,11 +31,9 @@ func NewNotifyingUUIDRepublisher(uuidCollectionRepublisher UUIDCollectionRepubli
 func (r *NotifyingUUIDRepublisher) Republish(uuid, tidPrefix string, republishScope string) (msgs []*OKMsg, errs []error) {
 	isFoundInAnyCollection := false
 	isScopedInAnyCollection := false
+	foundInUC := false
 
-	for _, collection := range r.collections {
-		if republishScope != ScopeBoth && republishScope != collection.scope {
-			continue
-		}
+	auxRepublish := func(collection CollectionMetadata) []*OKMsg {
 		tid := tidPrefix + transactionidutils.NewTransactionID()
 		isScopedInAnyCollection = true
 		msg, isFound, err := r.ucRepublisher.RepublishUUIDFromCollection(uuid, tid, collection)
@@ -47,6 +45,32 @@ func (r *NotifyingUUIDRepublisher) Republish(uuid, tidPrefix string, republishSc
 		}
 		if msg != nil {
 			msgs = append(msgs, msg)
+		}
+		return msgs
+	}
+
+	// If the scope matches spark's one - independently the uuid's type, there is no way to know that at this stage-
+	// 1 - it tries to republish it first in universal-content collection (spark) in case it succeed we're done
+	// 2 - in case the scope is ScopeBoth (content & metadata) and it has been republished in spark then it proceed to republish in metadata
+	// 3 - In case none of the above match then tries the old way, iterating all the collections, and whenever there is a match the uuid is republished. (could be more than one time)
+	// this is the current behaviour.
+	if republishScope == r.collections["universal-content"].scope || republishScope == ScopeBoth {
+		msgs = auxRepublish(r.collections["universal-content"])
+		foundInUC = isFoundInAnyCollection
+	}
+
+	if foundInUC && republishScope == ScopeBoth {
+		for _, collection := range r.collections {
+			if collection.scope == ScopeMetadata {
+				msgs = auxRepublish(collection)
+			}
+		}
+	} else if !isFoundInAnyCollection {
+		for _, collection := range r.collections {
+			if republishScope != ScopeBoth && republishScope != collection.scope {
+				continue
+			}
+			msgs = auxRepublish(collection)
 		}
 	}
 
@@ -62,7 +86,7 @@ func (r *NotifyingUUIDRepublisher) Republish(uuid, tidPrefix string, republishSc
 			return nil, errs
 		}
 		log.Infof("uuid=%v was found to be an ImageSet having an imageModelUUID=%v", uuid, imageModelUUID)
-		msg, isFound, err := r.ucRepublisher.RepublishUUIDFromCollection(imageModelUUID, tid, r.collections["methode"])
+		msg, isFound, err := r.ucRepublisher.RepublishUUIDFromCollection(imageModelUUID, tid, r.collections["universal-content"])
 		if err != nil {
 			errs = append(errs, fmt.Errorf("error publishing %v", err))
 			return nil, errs

--- a/pkg/republisher/uuid_republisher.go
+++ b/pkg/republisher/uuid_republisher.go
@@ -31,9 +31,10 @@ func NewNotifyingUUIDRepublisher(uuidCollectionRepublisher UUIDCollectionRepubli
 func (r *NotifyingUUIDRepublisher) Republish(uuid, tidPrefix string, republishScope string) (msgs []*OKMsg, errs []error) {
 	isFoundInAnyCollection := false
 	isScopedInAnyCollection := false
-	foundInUC := false
+	priorityCollection := r.collections["universal-content"]
+	isFoundInPriorityCollection := false
 
-	auxRepublish := func(collection CollectionMetadata) []*OKMsg {
+	republishFrom := func(collection CollectionMetadata) []*OKMsg {
 		tid := tidPrefix + transactionidutils.NewTransactionID()
 		isScopedInAnyCollection = true
 		msg, isFound, err := r.ucRepublisher.RepublishUUIDFromCollection(uuid, tid, collection)
@@ -49,28 +50,26 @@ func (r *NotifyingUUIDRepublisher) Republish(uuid, tidPrefix string, republishSc
 		return msgs
 	}
 
-	// If the scope matches spark's one - independently the uuid's type, there is no way to know that at this stage-
-	// 1 - it tries to republish it first in universal-content collection (spark) in case it succeed we're done
-	// 2 - in case the scope is ScopeBoth (content & metadata) and it has been republished in spark then it proceed to republish in metadata
-	// 3 - In case none of the above match then tries the old way, iterating all the collections, and whenever there is a match the uuid is republished. (could be more than one time)
-	// this is the current behaviour.
-	if republishScope == r.collections["universal-content"].scope || republishScope == ScopeBoth {
-		msgs = auxRepublish(r.collections["universal-content"])
-		foundInUC = isFoundInAnyCollection
-	}
-
-	if foundInUC && republishScope == ScopeBoth {
-		for _, collection := range r.collections {
-			if collection.scope == ScopeMetadata {
-				msgs = auxRepublish(collection)
+	if republishScope == ScopeBoth || republishScope == ScopeContent {
+		// try priority content collection first
+		msgs = republishFrom(priorityCollection)
+		isFoundInPriorityCollection = isFoundInAnyCollection
+		// if not found in priority, try all other content
+		if !isFoundInPriorityCollection {
+			for _, collection := range r.collections {
+				if collection.scope == ScopeContent {
+					msgs = republishFrom(collection)
+				}
 			}
 		}
-	} else if !isFoundInAnyCollection {
+	}
+
+	// republish metadata when scope requires it
+	if republishScope == ScopeBoth || republishScope == ScopeMetadata {
 		for _, collection := range r.collections {
-			if republishScope != ScopeBoth && republishScope != collection.scope {
-				continue
+			if collection.scope == ScopeMetadata {
+				msgs = republishFrom(collection)
 			}
-			msgs = auxRepublish(collection)
 		}
 	}
 

--- a/pkg/republisher/uuid_republisher_test.go
+++ b/pkg/republisher/uuid_republisher_test.go
@@ -49,9 +49,9 @@ var testCollections = Collections{
 }
 
 var testCollectionsSingle = Collections{
-	"methode": {
-		name:                  "methode",
-		defaultOriginSystemID: "methode-web-pub",
+	"universal-content": {
+		name:                  "universal-content",
+		defaultOriginSystemID: "cct",
 		notifierApp:           CmsNotifier,
 		scope:                 ScopeContent,
 	},
@@ -113,8 +113,8 @@ func TestNotScoped_Ok(t *testing.T) {
 	msg := OKMsg{
 		uuid:                     "b3ec9282-1073-46ad-9d44-144dad7fe956",
 		tid:                      "prefix1",
-		collectionName:           "methode",
-		collectionOriginSystemID: "methode-web-pub",
+		collectionName:           "universal-content",
+		collectionOriginSystemID: "cct",
 		sizeBytes:                1024,
 		notifierAppName:          "cms-notifier",
 	}
@@ -131,14 +131,14 @@ func TestFoundInNoneFoundInDocStore_Ok(t *testing.T) {
 	msg := OKMsg{
 		uuid:                     "64bc4319-cd22-43e9-8b12-358622d7a5ba",
 		tid:                      "prefix1tid_123",
-		collectionName:           "methode",
-		collectionOriginSystemID: "methode-web-pub",
+		collectionName:           "universal-content",
+		collectionOriginSystemID: "cct",
 		sizeBytes:                1024,
 		notifierAppName:          "cms-notifier",
 	}
 	var nilMsg *OKMsg
-	mockedUCRepublisher.On("RepublishUUIDFromCollection", "b3ec9282-1073-46ad-9d44-144dad7fe956", mock.MatchedBy(func(tid string) bool { return strings.HasPrefix(tid, "prefix1") }), testCollections["methode"]).Return(nilMsg, false, nil)
-	mockedUCRepublisher.On("RepublishUUIDFromCollection", "64bc4319-cd22-43e9-8b12-358622d7a5ba", mock.MatchedBy(func(tid string) bool { return strings.HasPrefix(tid, "prefix1") }), testCollections["methode"]).Return(&msg, true, nil)
+	mockedUCRepublisher.On("RepublishUUIDFromCollection", "b3ec9282-1073-46ad-9d44-144dad7fe956", mock.MatchedBy(func(tid string) bool { return strings.HasPrefix(tid, "prefix1") }), testCollections["universal-content"]).Return(nilMsg, false, nil)
+	mockedUCRepublisher.On("RepublishUUIDFromCollection", "64bc4319-cd22-43e9-8b12-358622d7a5ba", mock.MatchedBy(func(tid string) bool { return strings.HasPrefix(tid, "prefix1") }), testCollections["universal-content"]).Return(&msg, true, nil)
 	mockedDocStoreClient := new(mockDocStoreClient)
 	mockedDocStoreClient.On("GetImageSetsModelUUID", "b3ec9282-1073-46ad-9d44-144dad7fe956", mock.MatchedBy(func(tid string) bool { return strings.HasPrefix(tid, "prefix1") })).Return(true, "64bc4319-cd22-43e9-8b12-358622d7a5ba", nil)
 	r := NewNotifyingUUIDRepublisher(mockedUCRepublisher, mockedDocStoreClient, testCollectionsSingle)
@@ -155,14 +155,14 @@ func TestFoundInNoneErrInDocStore_Err(t *testing.T) {
 	msg := OKMsg{
 		uuid:                     "64bc4319-cd22-43e9-8b12-358622d7a5ba",
 		tid:                      "prefix1tid_123",
-		collectionName:           "methode",
-		collectionOriginSystemID: "methode-web-pub",
+		collectionName:           "universal-content",
+		collectionOriginSystemID: "cct",
 		sizeBytes:                1024,
 		notifierAppName:          "cms-notifier",
 	}
 	var nilMsg *OKMsg
-	mockedUCRepublisher.On("RepublishUUIDFromCollection", "b3ec9282-1073-46ad-9d44-144dad7fe956", mock.MatchedBy(func(tid string) bool { return strings.HasPrefix(tid, "prefix1") }), testCollections["methode"]).Return(nilMsg, false, nil)
-	mockedUCRepublisher.On("RepublishUUIDFromCollection", "64bc4319-cd22-43e9-8b12-358622d7a5ba", mock.MatchedBy(func(tid string) bool { return strings.HasPrefix(tid, "prefix1") }), testCollections["methode"]).Return(&msg, true, nil)
+	mockedUCRepublisher.On("RepublishUUIDFromCollection", "b3ec9282-1073-46ad-9d44-144dad7fe956", mock.MatchedBy(func(tid string) bool { return strings.HasPrefix(tid, "prefix1") }), testCollections["universal-content"]).Return(nilMsg, false, nil)
+	mockedUCRepublisher.On("RepublishUUIDFromCollection", "64bc4319-cd22-43e9-8b12-358622d7a5ba", mock.MatchedBy(func(tid string) bool { return strings.HasPrefix(tid, "prefix1") }), testCollections["universal-content"]).Return(&msg, true, nil)
 	mockedDocStoreClient := new(mockDocStoreClient)
 	mockedDocStoreClient.On("GetImageSetsModelUUID", "b3ec9282-1073-46ad-9d44-144dad7fe956", mock.MatchedBy(func(tid string) bool { return strings.HasPrefix(tid, "prefix1") })).Return(false, "", fmt.Errorf("error in dsapi, maybe 401"))
 	r := NewNotifyingUUIDRepublisher(mockedUCRepublisher, mockedDocStoreClient, testCollectionsSingle)
@@ -179,14 +179,14 @@ func TestFoundInNoneAndNotFoundInDocStore_Ok(t *testing.T) {
 	msg := OKMsg{
 		uuid:                     "64bc4319-cd22-43e9-8b12-358622d7a5ba",
 		tid:                      "prefix1tid_123",
-		collectionName:           "methode",
-		collectionOriginSystemID: "methode-web-pub",
+		collectionName:           "universal-content",
+		collectionOriginSystemID: "cct",
 		sizeBytes:                1024,
 		notifierAppName:          "cms-notifier",
 	}
 	var nilMsg *OKMsg
-	mockedUCRepublisher.On("RepublishUUIDFromCollection", "b3ec9282-1073-46ad-9d44-144dad7fe956", mock.MatchedBy(func(tid string) bool { return strings.HasPrefix(tid, "prefix1") }), testCollections["methode"]).Return(nilMsg, false, nil)
-	mockedUCRepublisher.On("RepublishUUIDFromCollection", "64bc4319-cd22-43e9-8b12-358622d7a5ba", mock.MatchedBy(func(tid string) bool { return strings.HasPrefix(tid, "prefix1") }), testCollections["methode"]).Return(&msg, true, nil)
+	mockedUCRepublisher.On("RepublishUUIDFromCollection", "b3ec9282-1073-46ad-9d44-144dad7fe956", mock.MatchedBy(func(tid string) bool { return strings.HasPrefix(tid, "prefix1") }), testCollections["universal-content"]).Return(nilMsg, false, nil)
+	mockedUCRepublisher.On("RepublishUUIDFromCollection", "64bc4319-cd22-43e9-8b12-358622d7a5ba", mock.MatchedBy(func(tid string) bool { return strings.HasPrefix(tid, "prefix1") }), testCollections["universal-content"]).Return(&msg, true, nil)
 	mockedDocStoreClient := new(mockDocStoreClient)
 	mockedDocStoreClient.On("GetImageSetsModelUUID", "b3ec9282-1073-46ad-9d44-144dad7fe956", mock.MatchedBy(func(tid string) bool { return strings.HasPrefix(tid, "prefix1") })).Return(false, "", nil)
 	r := NewNotifyingUUIDRepublisher(mockedUCRepublisher, mockedDocStoreClient, testCollectionsSingle)


### PR DESCRIPTION
# Description

## What
Improve logic whenever a spark UUID is republished, in order to be republished in and only in Spark, in case it does not exist then it is republished wherever exists.
## Why

Copy (if there is one) the text of the original Trello/JIRA ticket in here, with a link back to it for the curious.

## Anything, in particular, you'd like to highlight to reviewers

Mention here sections of code which you would like reviewers to pay extra attention to .E.g

_Would appreciate a second pair of eyes on the test_  
_I am not quite sure how this bit works_  
_Is there a better library for doing x_  

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [x] Bug fix
- [X] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
