### PR TITLE
Added push-to-dockerhub to circleci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,16 +3,35 @@ version: 2.1
 orbs:
   ft-golang-ci: financial-times/golang-ci@1
 
+jobs:
+  build-and-publish-docker-image:
+    docker:
+      - image: docker:stable-git
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run:
+          name: Build Docker image
+          command: docker build --tag coco/publish-failure-resolver-go:latest .
+      - run:
+          name: Login in Dockerhub
+          command: echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_LOGIN" --password-stdin
+      - deploy:
+          name: Push Docker image
+          command: docker push coco/publish-failure-resolver-go:latest
+
 workflows:
   tests_and_docker:
     jobs:
       - ft-golang-ci/build-and-test:
           name: build-and-test-project
-
-      - ft-golang-ci/docker-build:
-          name: build-docker-image
+      - build-and-publish-docker-image:
+          name: build-and-publish-docker-image
           requires:
             - build-and-test-project
+          filters:
+            branches:
+              only: "master"
 
   snyk-scanning:
     jobs:


### PR DESCRIPTION
# Description

Pushing build images to dockerhub.

## What

Added step in the circleci configuration to push the builded docker image to dockerhub.

## Why

https://financialtimes.atlassian.net/browse/UPPSF-3253

## Anything, in particular, you'd like to highlight to reviewers

There is theoretically better way to do this by using the [docker orb](https://circleci.com/developer/orbs/orb/circleci/docker#usage-build-and-update), but i couldn't make it work.

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Breaking change
- [x] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
