### PR TITLE
use cm-team-dockerhub context

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
           command: docker build --tag coco/publish-failure-resolver-go:latest .
       - run:
           name: Login in Dockerhub
-          command: echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_LOGIN" --password-stdin
+          command: echo "$DOCKER_ACCESS_TOKEN" | docker login -u "$DOCKER_USER" --password-stdin
       - deploy:
           name: Push Docker image
           command: docker push coco/publish-failure-resolver-go:latest
@@ -32,6 +32,7 @@ workflows:
           filters:
             branches:
               only: "master"
+          context: cm-team-dockerhub
 
   snyk-scanning:
     jobs:


### PR DESCRIPTION
# Description

## What

Use cm-team-dockerhub context instead of environment variables for pushing images to dockerhub.

## Why

[JIRA](https://financialtimes.atlassian.net/browse/UPPSF-4316)

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Breaking change
- [x] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
