### PR TITLE
Upgrade Go 1.25 → 1.26

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Financial-Times/publish-failure-resolver-go
 
-go 1.25
+go 1.26
 
 require (
 	github.com/Financial-Times/transactionid-utils-go v1.1.0


### PR DESCRIPTION
# Description

## What

Automated upgrade of Go references from `1.25` to `1.26`.
- `go.mod`: bumped only when it declared `go 1.25`
- Dockerfiles: `golang:1.26` (preserving tag suffixes like `-alpine`)
- CI (GitHub Actions/CircleCI): matrices, `go-version`, and `GO_VERSION` vars updated (`1.26`)
- `.go-version` / `.tool-versions`: set to `1.26`

A `go mod tidy` was run for modules that changed.

## Why

Estate-wide alignment on Go `1.26` to match current platform/tooling and reduce drift.
Link to ticket: https://financialtimes.atlassian.net/browse/UPPSF-7052

## Anything, in particular, you'd like to highlight to reviewers

- Please sanity check CI workflows if they pinned older images or used custom version matrices.
- Confirm any multi-module repos built as expected after the bump.

## Scope and particulars of this PR (Please tick all that apply)

- [x] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Breaking change
- [x] Minor change (e.g. fixing a typo, adding config)

## DoD - Ensure all relevant tasks are completed before marking this PR as "Ready for review"

- [x] Test coverage is not significantly decreased
- [x] All PR checks have passed
- [ ] Changes are deployed on dev before asking for review
- [ ] Documentations remains up-to-date
- [ ] OpenAPI definition file is updated
- [ ] README file is updated
- [ ] Documentation is updated in upp-docs and upp-public-docs
- [ ] Architecture diagrams are updated

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)